### PR TITLE
Only verify FEEL expressions; warn that others are currently unsupported

### DIFF
--- a/validators/pom.xml
+++ b/validators/pom.xml
@@ -30,6 +30,13 @@
             <version>3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/validators/src/main/java/de/redsix/dmncheck/util/Expression.java
+++ b/validators/src/main/java/de/redsix/dmncheck/util/Expression.java
@@ -1,0 +1,29 @@
+package de.redsix.dmncheck.util;
+
+import org.camunda.bpm.model.dmn.impl.DmnModelConstants;
+import org.camunda.bpm.model.dmn.instance.LiteralExpression;
+import org.camunda.bpm.model.dmn.instance.UnaryTests;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+public class Expression {
+
+    public final String textContent;
+    public final String expressionLanguage;
+
+    public Expression(final UnaryTests unaryTests, final @Nullable String toplevelExpressionLanguage) {
+        this.textContent = unaryTests.getTextContent();
+        this.expressionLanguage = decideExpressionLanguage(unaryTests.getExpressionLanguage(), toplevelExpressionLanguage);
+    }
+
+    public Expression(final LiteralExpression literalExpression, final @Nullable String toplevelExpressionLanguage) {
+        this.textContent = literalExpression.getTextContent();
+        this.expressionLanguage = decideExpressionLanguage(literalExpression.getExpressionLanguage(), toplevelExpressionLanguage);
+    }
+
+    private static String decideExpressionLanguage(final String localExpressionLanguage, final @Nullable String toplevelExpressionLanguage) {
+        return Objects.requireNonNullElseGet(localExpressionLanguage,
+                () -> Objects.requireNonNullElse(toplevelExpressionLanguage, DmnModelConstants.FEEL_NS));
+    }
+}

--- a/validators/src/main/java/de/redsix/dmncheck/util/TopLevelExpressionLanguage.java
+++ b/validators/src/main/java/de/redsix/dmncheck/util/TopLevelExpressionLanguage.java
@@ -1,0 +1,23 @@
+package de.redsix.dmncheck.util;
+
+import org.camunda.bpm.model.dmn.instance.LiteralExpression;
+import org.camunda.bpm.model.dmn.instance.UnaryTests;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class TopLevelExpressionLanguage {
+
+    @Nullable
+    public final String topLevelExpressionLanguage;
+
+    public TopLevelExpressionLanguage(final @Nullable String topLevelExpressionLanguage) {
+        this.topLevelExpressionLanguage = topLevelExpressionLanguage;
+    }
+
+    public Expression toExpression(final UnaryTests unaryTests) {
+        return new Expression(unaryTests, topLevelExpressionLanguage);
+    }
+
+    public Expression toExpression(final LiteralExpression literalExpression) {
+        return new Expression(literalExpression, topLevelExpressionLanguage);
+    }
+}

--- a/validators/src/main/java/de/redsix/dmncheck/validators/ConnectedRequirementGraphValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/ConnectedRequirementGraphValidator.java
@@ -5,7 +5,10 @@ import de.redsix.dmncheck.feel.FeelExpression;
 import de.redsix.dmncheck.feel.FeelParser;
 import de.redsix.dmncheck.result.ValidationResult;
 import de.redsix.dmncheck.util.Either;
+import de.redsix.dmncheck.util.Expression;
+import de.redsix.dmncheck.util.TopLevelExpressionLanguage;
 import de.redsix.dmncheck.validators.core.RequirementGraphValidator;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Decision;
 import org.camunda.bpm.model.dmn.instance.DecisionTable;
 import org.camunda.bpm.model.dmn.instance.DrgElement;
@@ -23,6 +26,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ConnectedRequirementGraphValidator extends RequirementGraphValidator {
+
+    private TopLevelExpressionLanguage toplevelExpressionLanguage = new TopLevelExpressionLanguage(null);
+
+    @Override
+    public List<ValidationResult> apply(final DmnModelInstance dmnModelInstance) {
+        toplevelExpressionLanguage = new TopLevelExpressionLanguage(dmnModelInstance.getDefinitions().getExpressionLanguage());
+        return super.apply(dmnModelInstance);
+    }
 
     @Override
     public List<ValidationResult> validate(RequirementGraph drg) {
@@ -59,7 +70,7 @@ public class ConnectedRequirementGraphValidator extends RequirementGraphValidato
 
             final Either<ValidationResult.Builder.ElementStep, List<FeelExpression>> eitherInputExpressions = targetDecisionTable.getInputs().stream()
                     .map(Input::getInputExpression)
-                    .map(InputExpression::getTextContent)
+                    .map(toplevelExpressionLanguage::toExpression)
                     .map(FeelParser::parse)
                     .collect(Either.reduce());
 

--- a/validators/src/main/java/de/redsix/dmncheck/validators/InputEntryTypeValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/InputEntryTypeValidator.java
@@ -4,6 +4,7 @@ import de.redsix.dmncheck.feel.ExpressionType;
 import de.redsix.dmncheck.feel.ExpressionTypeParser;
 import de.redsix.dmncheck.result.ValidationResult;
 import de.redsix.dmncheck.util.Either;
+import de.redsix.dmncheck.util.Expression;
 import de.redsix.dmncheck.validators.core.ValidationContext;
 import org.camunda.bpm.model.dmn.instance.DecisionTable;
 import org.camunda.bpm.model.dmn.instance.Input;
@@ -34,7 +35,10 @@ public class InputEntryTypeValidator extends TypeValidator<DecisionTable> {
 
             return eitherInputTypes.match(
                     validationResult -> Stream.of(validationResult.element(rule).build()),
-                    inputTypes -> typecheck(rule, rule.getInputEntries().stream(), inputVariables, inputTypes.stream()));
+                    inputTypes -> typecheck(rule,
+                            rule.getInputEntries().stream().map(toplevelExpressionLanguage::toExpression),
+                            inputVariables,
+                            inputTypes.stream()));
         }).collect(Collectors.toList());
     }
 

--- a/validators/src/main/java/de/redsix/dmncheck/validators/InputValuesTypeValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/InputValuesTypeValidator.java
@@ -2,6 +2,7 @@ package de.redsix.dmncheck.validators;
 
 import de.redsix.dmncheck.feel.ExpressionTypeParser;
 import de.redsix.dmncheck.result.ValidationResult;
+import de.redsix.dmncheck.util.Expression;
 import de.redsix.dmncheck.validators.core.ValidationContext;
 import org.camunda.bpm.model.dmn.instance.Input;
 
@@ -25,8 +26,9 @@ public class InputValuesTypeValidator extends TypeValidator<Input> {
 
         return ExpressionTypeParser.parse(expressionType, validationContext.getItemDefinitions())
                 .match(validationResult -> Collections.singletonList(validationResult.element(input).build()),
-                        inputType -> typecheck(input, Stream.of(input.getInputValues()), Stream.of(inputType))
-                                .collect(Collectors.toList()));
+                        inputType -> typecheck(input,
+                                Stream.of(input.getInputValues()).map(toplevelExpressionLanguage::toExpression),
+                                Stream.of(inputType)).collect(Collectors.toList()));
     }
 
     @Override

--- a/validators/src/main/java/de/redsix/dmncheck/validators/ItemDefinitionAllowedValuesTypeValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/ItemDefinitionAllowedValuesTypeValidator.java
@@ -3,6 +3,7 @@ package de.redsix.dmncheck.validators;
 import de.redsix.dmncheck.feel.ExpressionTypeParser;
 import de.redsix.dmncheck.result.Severity;
 import de.redsix.dmncheck.result.ValidationResult;
+import de.redsix.dmncheck.util.Expression;
 import de.redsix.dmncheck.validators.core.ValidationContext;
 import org.camunda.bpm.model.dmn.instance.ItemDefinition;
 
@@ -44,8 +45,9 @@ public class ItemDefinitionAllowedValuesTypeValidator extends TypeValidator<Item
                    return ExpressionTypeParser
                        .parse(expressionType, validationContext.getItemDefinitions())
                        .match(validationResult -> Stream.of(validationResult.element(itemDefinitionOrComponent).build()),
-                              inputType -> typecheck(itemDefinitionOrComponent, Stream.of(itemDefinitionOrComponent.getAllowedValues()),
-                                                     Stream.of(inputType)));
+                              inputType -> typecheck(itemDefinitionOrComponent,
+                                      Stream.of(itemDefinitionOrComponent.getAllowedValues()).map(toplevelExpressionLanguage::toExpression),
+                                      Stream.of(inputType)));
                }})
             .collect(Collectors.toList());
     }

--- a/validators/src/main/java/de/redsix/dmncheck/validators/OutputEntryTypeValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/OutputEntryTypeValidator.java
@@ -4,6 +4,7 @@ import de.redsix.dmncheck.feel.ExpressionType;
 import de.redsix.dmncheck.feel.ExpressionTypeParser;
 import de.redsix.dmncheck.result.ValidationResult;
 import de.redsix.dmncheck.util.Either;
+import de.redsix.dmncheck.util.Expression;
 import de.redsix.dmncheck.validators.core.ValidationContext;
 import org.camunda.bpm.model.dmn.instance.DecisionTable;
 import org.camunda.bpm.model.dmn.instance.OutputClause;
@@ -32,8 +33,9 @@ public class OutputEntryTypeValidator extends TypeValidator<DecisionTable> {
         return decisionTable.getRules().stream().flatMap(rule ->
                 eitherOutputTypes.match(
                         validationResult -> Stream.of(validationResult.element(rule).build()),
-                        outputTypes -> typecheck(rule, rule.getOutputEntries().stream(), outputTypes.stream())))
-                .collect(Collectors.toList());
+                        outputTypes -> typecheck(rule,
+                                rule.getOutputEntries().stream().map(toplevelExpressionLanguage::toExpression),
+                                outputTypes.stream()))).collect(Collectors.toList());
     }
 
     @Override

--- a/validators/src/main/java/de/redsix/dmncheck/validators/OutputValuesTypeValidator.java
+++ b/validators/src/main/java/de/redsix/dmncheck/validators/OutputValuesTypeValidator.java
@@ -2,6 +2,7 @@ package de.redsix.dmncheck.validators;
 
 import de.redsix.dmncheck.feel.ExpressionTypeParser;
 import de.redsix.dmncheck.result.ValidationResult;
+import de.redsix.dmncheck.util.Expression;
 import de.redsix.dmncheck.validators.core.ValidationContext;
 import org.camunda.bpm.model.dmn.instance.Output;
 
@@ -25,8 +26,9 @@ public class OutputValuesTypeValidator extends TypeValidator<Output> {
 
         return ExpressionTypeParser.parse(expressionType, validationContext.getItemDefinitions())
                 .match(validationResult -> Collections.singletonList(validationResult.element(output).build()),
-                        inputType -> typecheck(output, Stream.of(output.getOutputValues()), Stream.of(inputType))
-                                .collect(Collectors.toList()));
+                       inputType -> typecheck(output,
+                                Stream.of(output.getOutputValues()).map(toplevelExpressionLanguage::toExpression),
+                                Stream.of(inputType)).collect(Collectors.toList()));
     }
 
     @Override

--- a/validators/src/test/java/de/redsix/dmncheck/feel/FeelParserTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/feel/FeelParserTest.java
@@ -3,10 +3,16 @@ package de.redsix.dmncheck.feel;
 import de.redsix.dmncheck.result.ValidationResult;
 import de.redsix.dmncheck.util.Either;
 import de.redsix.dmncheck.util.Eithers;
+import de.redsix.dmncheck.util.Expression;
+import org.camunda.bpm.model.dmn.impl.DmnModelConstants;
+import org.camunda.bpm.model.dmn.impl.instance.LiteralExpressionImpl;
+import org.camunda.bpm.model.dmn.instance.LiteralExpression;
+import org.camunda.bpm.model.dmn.instance.UnaryTests;
 import org.jparsec.error.ParserException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -26,6 +32,7 @@ import static de.redsix.dmncheck.feel.FeelExpressions.VariableLiteral;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 class FeelParserTest {
 
@@ -340,5 +347,32 @@ class FeelParserTest {
 
         assertTrue(Eithers.getLeft(result).isPresent());
         assertEquals(expectedErrorMessage, Eithers.getLeft(result).get().getMessage());
+    }
+
+    @Test
+    void shouldWarnIfExpressionLanguageIsNotFeel() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getExpressionLanguage()).thenReturn("javascript");
+        final Expression expression = new Expression(literalExpression, null);
+
+        final Either<ValidationResult.Builder.ElementStep, FeelExpression> result = FeelParser.parse(expression);
+        final String expectedErrorMessage = "Expression language 'javascript' not supported";
+
+        assertTrue(Eithers.getLeft(result).isPresent());
+        assertEquals(expectedErrorMessage, Eithers.getLeft(result).get().getMessage());
+    }
+
+    @Test
+    void shouldParseEmptyFromExpression() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getExpressionLanguage()).thenReturn(DmnModelConstants.FEEL_NS);
+        when(literalExpression.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(literalExpression, null);
+
+        final Either<ValidationResult.Builder.ElementStep, FeelExpression> result = FeelParser.parse(expression);
+
+        assertTrue(Eithers.getRight(result).isPresent());
+        assertEquals(FeelExpressions.Empty(), Eithers.getRight(result).get());
     }
 }

--- a/validators/src/test/java/de/redsix/dmncheck/util/ExpressionTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/util/ExpressionTest.java
@@ -1,0 +1,106 @@
+package de.redsix.dmncheck.util;
+
+import org.camunda.bpm.model.dmn.impl.DmnModelConstants;
+import org.camunda.bpm.model.dmn.instance.LiteralExpression;
+import org.camunda.bpm.model.dmn.instance.UnaryTests;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class ExpressionTest {
+
+    @Test
+    void shouldCreateExpressionFromUnaryTestsWithLocalExpressionLanguage() {
+        final UnaryTests unaryTests = Mockito.mock(UnaryTests.class);
+        when(unaryTests.getExpressionLanguage()).thenReturn(DmnModelConstants.FEEL_NS);
+        when(unaryTests.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(unaryTests, null);
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldCreateExpressionFromLiteralExpressionWithLocalExpressionLanguage() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getExpressionLanguage()).thenReturn(DmnModelConstants.FEEL_NS);
+        when(literalExpression.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(literalExpression, null);
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldFavorLocalExpressionLanguageUnaryTests() {
+        final UnaryTests unaryTests = Mockito.mock(UnaryTests.class);
+        when(unaryTests.getExpressionLanguage()).thenReturn(DmnModelConstants.FEEL_NS);
+        when(unaryTests.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(unaryTests, "javascript");
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldFavorLocalExpressionLanguageLiteralExpression() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getExpressionLanguage()).thenReturn(DmnModelConstants.FEEL_NS);
+        when(literalExpression.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(literalExpression, "javascript");
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+
+    @Test
+    void shouldUseTopLevelIfLocalExpressionLanguageIsMissingUnaryTests() {
+        final UnaryTests unaryTests = Mockito.mock(UnaryTests.class);
+        when(unaryTests.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(unaryTests, "javascript");
+
+        assertEquals("javascript", expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldUseTopLevelIfLocalExpressionLanguageIsMissingLiteralExpression() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(literalExpression, "javascript");
+
+        assertEquals("javascript", expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldUseFeelIfNothingIsSpecifiedUnaryTests() {
+        final UnaryTests unaryTests = Mockito.mock(UnaryTests.class);
+        when(unaryTests.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(unaryTests, null);
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+
+    @Test
+    void shouldUseFeelIfNothingIsSpecifiedLiteralExpression() {
+        final LiteralExpression literalExpression = Mockito.mock(LiteralExpression.class);
+        when(literalExpression.getTextContent()).thenReturn("");
+
+        final Expression expression = new Expression(literalExpression, null);
+
+        assertEquals(DmnModelConstants.FEEL_NS, expression.expressionLanguage);
+        assertEquals("", expression.textContent);
+    }
+}

--- a/validators/src/test/java/de/redsix/dmncheck/validators/ConnectedRequirementGraphValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/ConnectedRequirementGraphValidatorTest.java
@@ -5,16 +5,7 @@ import de.redsix.dmncheck.result.ValidationResult;
 import de.redsix.dmncheck.validators.util.WithDecisionTable;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
-import org.camunda.bpm.model.dmn.instance.AuthorityRequirement;
-import org.camunda.bpm.model.dmn.instance.Decision;
-import org.camunda.bpm.model.dmn.instance.DecisionTable;
-import org.camunda.bpm.model.dmn.instance.Definitions;
-import org.camunda.bpm.model.dmn.instance.InformationRequirement;
-import org.camunda.bpm.model.dmn.instance.Input;
-import org.camunda.bpm.model.dmn.instance.InputData;
-import org.camunda.bpm.model.dmn.instance.InputExpression;
-import org.camunda.bpm.model.dmn.instance.KnowledgeSource;
-import org.camunda.bpm.model.dmn.instance.Output;
+import org.camunda.bpm.model.dmn.instance.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/validators/src/test/java/de/redsix/dmncheck/validators/InputEntryTypeValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/InputEntryTypeValidatorTest.java
@@ -229,4 +229,30 @@ class InputEntryTypeValidatorTest extends WithDecisionTable {
                 () -> assertEquals(Severity.ERROR, validationResult.getSeverity())
         );
     }
+
+    @Test
+    void warnsIfAnOtherExpressionLanguageThanFeelIsUsed() {
+        final Input input = modelInstance.newInstance(Input.class);
+        final InputExpression inputExpression = modelInstance.newInstance(InputExpression.class);
+        input.setInputExpression(inputExpression);
+        decisionTable.getInputs().add(input);
+
+        final Rule rule = modelInstance.newInstance(Rule.class);
+        final InputEntry inputEntry = modelInstance.newInstance(InputEntry.class);
+        inputEntry.setTextContent("'foo'.repeat(6)");
+        inputEntry.setExpressionLanguage("javascript");
+        rule.getInputEntries().add(inputEntry);
+        decisionTable.getRules().add(rule);
+
+        final List<ValidationResult> validationResults = testee.apply(modelInstance);
+
+        assertEquals(1, validationResults.size());
+        final ValidationResult validationResult = validationResults.get(0);
+        assertAll(
+                () -> assertEquals("Expression language 'javascript' not supported",
+                        validationResult.getMessage()),
+                () -> assertEquals(rule, validationResult.getElement()),
+                () -> assertEquals(Severity.WARNING, validationResult.getSeverity())
+        );
+    }
 }

--- a/validators/src/test/java/de/redsix/dmncheck/validators/InputValuesTypeValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/InputValuesTypeValidatorTest.java
@@ -74,4 +74,30 @@ class InputValuesTypeValidatorTest extends WithDecisionTable {
         );
     }
 
+    @Test
+    void warnsIfAnOtherExpressionLanguageThanFeelIsUsed() {
+        final Input input = modelInstance.newInstance(Input.class);
+        final InputValues inputValues = modelInstance.newInstance(InputValues.class);
+        inputValues.setTextContent("'foo'.repeat(6)");
+        inputValues.setExpressionLanguage("javascript");
+        input.setInputValues(inputValues);
+
+        final InputExpression inputExpression = modelInstance.newInstance(InputExpression.class);
+        input.setInputExpression(inputExpression);
+        inputExpression.setTypeRef("string");
+
+        decisionTable.getInputs().add(input);
+
+        final List<ValidationResult> validationResults = testee.apply(modelInstance);
+
+        assertEquals(1, validationResults.size());
+        final ValidationResult validationResult = validationResults.get(0);
+        assertAll(
+                () -> assertEquals("Expression language 'javascript' not supported",
+                        validationResult.getMessage()),
+                () -> assertEquals(input, validationResult.getElement()),
+                () -> assertEquals(Severity.WARNING, validationResult.getSeverity())
+        );
+    }
+
 }

--- a/validators/src/test/java/de/redsix/dmncheck/validators/ItemDefinitionAllowedValuesTypeValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/ItemDefinitionAllowedValuesTypeValidatorTest.java
@@ -109,4 +109,28 @@ class ItemDefinitionAllowedValuesTypeValidatorTest extends WithItemDefinition {
         );
     }
 
+    @Test
+    void warnsIfAnOtherExpressionLanguageThanFeelIsUsed() {
+        final TypeRef typeRef = modelInstance.newInstance(TypeRef.class);
+        typeRef.setTextContent("string");
+
+        final AllowedValues allowedValues = modelInstance.newInstance(AllowedValues.class);
+        allowedValues.setTextContent("'foo'.repeat(6)");
+        allowedValues.setExpressionLanguage("javascript");
+
+        itemDefinition.setTypeRef(typeRef);
+        itemDefinition.setAllowedValues(allowedValues);
+
+        final List<ValidationResult> validationResults = testee.apply(modelInstance);
+
+        assertEquals(1, validationResults.size());
+        final ValidationResult validationResult = validationResults.get(0);
+        assertAll(
+                () -> assertEquals("Expression language 'javascript' not supported",
+                        validationResult.getMessage()),
+                () -> assertEquals(itemDefinition, validationResult.getElement()),
+                () -> assertEquals(Severity.WARNING, validationResult.getSeverity())
+        );
+    }
+
 }

--- a/validators/src/test/java/de/redsix/dmncheck/validators/OutputEntryTypeValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/OutputEntryTypeValidatorTest.java
@@ -98,4 +98,28 @@ class OutputEntryTypeValidatorTest extends WithDecisionTable {
                 () -> assertEquals(Severity.ERROR, validationResult.getSeverity())
         );
     }
+
+    @Test
+    void warnsIfAnOtherExpressionLanguageThanFeelIsUsed() {
+        final Output output = modelInstance.newInstance(Output.class);
+        decisionTable.getOutputs().add(output);
+
+        final Rule rule = modelInstance.newInstance(Rule.class);
+        final OutputEntry outputEntry = modelInstance.newInstance(OutputEntry.class);
+        outputEntry.setTextContent("'foo'.repeat(6)");
+        outputEntry.setExpressionLanguage("javascript");
+        rule.getOutputEntries().add(outputEntry);
+        decisionTable.getRules().add(rule);
+
+        final List<ValidationResult> validationResults = testee.apply(modelInstance);
+
+        assertEquals(1, validationResults.size());
+        final ValidationResult validationResult = validationResults.get(0);
+        assertAll(
+                () -> assertEquals("Expression language 'javascript' not supported",
+                        validationResult.getMessage()),
+                () -> assertEquals(rule, validationResult.getElement()),
+                () -> assertEquals(Severity.WARNING, validationResult.getSeverity())
+        );
+    }
 }

--- a/validators/src/test/java/de/redsix/dmncheck/validators/OutputValuesTypeValidatorTest.java
+++ b/validators/src/test/java/de/redsix/dmncheck/validators/OutputValuesTypeValidatorTest.java
@@ -35,7 +35,6 @@ class OutputValuesTypeValidatorTest extends WithDecisionTable {
         output.setOutputValues(OutputValues);
         output.setTypeRef("string");
 
-
         decisionTable.getOutputs().add(output);
 
         final List<ValidationResult> validationResults = testee.apply(modelInstance);
@@ -62,6 +61,29 @@ class OutputValuesTypeValidatorTest extends WithDecisionTable {
                         validationResult.getMessage()),
                 () -> assertEquals(output, validationResult.getElement()),
                 () -> assertEquals(Severity.ERROR, validationResult.getSeverity())
+        );
+    }
+
+    @Test
+    void warnsIfAnOtherExpressionLanguageThanFeelIsUsed() {
+        final Output output = modelInstance.newInstance(Output.class);
+        final OutputValues outputValues = modelInstance.newInstance(OutputValues.class);
+        outputValues.setTextContent("'foo'.repeat(6)");
+        outputValues.setExpressionLanguage("javascript");
+        output.setOutputValues(outputValues);
+        output.setTypeRef("string");
+
+        decisionTable.getOutputs().add(output);
+
+        final List<ValidationResult> validationResults = testee.apply(modelInstance);
+
+        assertEquals(1, validationResults.size());
+        final ValidationResult validationResult = validationResults.get(0);
+        assertAll(
+                () -> assertEquals("Expression language 'javascript' not supported",
+                        validationResult.getMessage()),
+                () -> assertEquals(output, validationResult.getElement()),
+                () -> assertEquals(Severity.WARNING, validationResult.getSeverity())
         );
     }
 


### PR DESCRIPTION
Currently, `dmn-check` only supports analysis of FEEL expressions. With this
commit the expression language that is specified in the DMN file is honored and
a warning is issued for all other expression languages.

Support for other expression languages is on the roadmap but with no schedule so
far. This feature makes `dmn-check` useable if other expression languages are
used in a DMN file, see issue #88.

Closes issue #83.